### PR TITLE
Fix gatekeep-constraint chart

### DIFF
--- a/charts/gatekeeper-library/templates/constraints.yaml
+++ b/charts/gatekeeper-library/templates/constraints.yaml
@@ -5,10 +5,10 @@
 {{- $name := dig "metadata" "name" "" $obj -}}
 {{- if and (eq (dig "apiVersion" "" $obj) "constraints.gatekeeper.sh/v1beta1") (dig $kind $name true $.Values.enableConstraints) -}}
 # {{ $path }}
-{{ toString $content | trim }}
 {{- with $.Values.enforcementAction }}
-  enforcementAction: {{ . }}
+  {{ $obj = mergeOverwrite $obj (dict "spec" (dict "enforcementAction" . )) }}
 {{ end -}}
+{{ toYaml $obj }}
 ---
 {{ end -}}
 {{- end -}}


### PR DESCRIPTION
https://github.com/kubeops/installer/blob/master/charts/gatekeeper-library/library/general/horizontalpodautoscaler/samples/horizontalpodautoscaler/constraint.yaml#L6

was causing the following error

```
      Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
        line 22: mapping key "enforcementAction" already defined at line 11
```