### PR TITLE
Add existing secret for kubeconfig

### DIFF
--- a/charts/config-syncer/templates/deployment.yaml
+++ b/charts/config-syncer/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
       {{- end }}
       {{- if .Values.config.kubeconfigContent }}
         - --kubeconfig-file=/srv/config-syncer/kubeconfig
+      {{- else if .Values.config.existingSecret.name }}
+        - --kubeconfig-file=/srv/config-syncer/{{ default "kubeconfig" .Values.config.existingSecret.kubeconfigKey }}
       {{- end }}
       {{- range .Values.config.additionalOptions }}
         - {{ . }}
@@ -96,7 +98,11 @@ spec:
       volumes:
       - name: config
         secret:
+          {{- if .Values.config.existingSecret.name }}
+          secretName: {{ .Values.config.existingSecret.name }}
+          {{- else }}
           secretName: {{ template "config-syncer.fullname" . }}
+          {{- end }}
       - name: scratch
         emptyDir: {}
       - name: serving-cert

--- a/charts/config-syncer/templates/secret.yaml
+++ b/charts/config-syncer/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   {{- if .Values.config.kubeconfigContent }}
   kubeconfig: {{ .Values.config.kubeconfigContent | trim | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/config-syncer/values.yaml
+++ b/charts/config-syncer/values.yaml
@@ -81,7 +81,7 @@ tolerations: []
 affinity: {}
 
 # Security options the operator pod should run with.
-podSecurityContext:  # +doc-gen:break
+podSecurityContext: # +doc-gen:break
   # ensure that s/a token is readable xref: https://issues.k8s.io/70679
   fsGroup: 65534
 
@@ -121,5 +121,11 @@ config:
   configSourceNamespace: ""
   # kubeconfig file content for configmap and secret syncer
   kubeconfigContent: ""
+  # Use existing secret
+  existingSecret:
+    # Name of existing secret
+    name: ""
+    # The kubeconfig key in secret
+    kubeconfigKey: kubeconfig
   additionalOptions: []
   # - --authentication-skip-lookup


### PR DESCRIPTION
This PR add `config.existingSecret` section for support external config secrets.

This fix https://github.com/kubeops/config-syncer/issues/531.

This is "clone" of https://github.com/kubeops/config-syncer/pull/532 because of fail of my rebase and https://github.com/kubeops/config-syncer/pull/547 due to moved chart.