### PR TITLE
fix(config-syncer): b64enc `$serverKey` and `$serverCrt`

### DIFF
--- a/charts/config-syncer/templates/apiregistration.yaml
+++ b/charts/config-syncer/templates/apiregistration.yaml
@@ -9,8 +9,8 @@
 {{- $serverCrt = b64enc $server.Cert }}
 {{- $serverKey = b64enc $server.Key }}
 {{- else }}
-{{- $serverCrt = required "Required when apiserver.servingCerts.generate is false" .Values.apiserver.servingCerts.serverCrt }}
-{{- $serverKey = required "Required when apiserver.servingCerts.generate is false" .Values.apiserver.servingCerts.serverKey }}
+{{- $serverCrt = required "Required when apiserver.servingCerts.generate is false" .Values.apiserver.servingCerts.serverCrt | b64enc }}
+{{- $serverKey = required "Required when apiserver.servingCerts.generate is false" .Values.apiserver.servingCerts.serverKey | b64enc }}
 {{- end }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Hi!

I believe in most cases people provide certificates by `--set-file`.

```bash
helm install config-syncer \
  --set-file apiserver.servingCerts.serverCrt=config-syncer.crt \
  --set-file apiserver.servingCerts.serverKey=config-syncer.key \
  config-syncer
```

The files(e.g. *`config-syncer.crt`*, *`config-syncer.crt`*) are not base64 encoded in general. 
So the chart should `b64enc` by itself.

Thanks :)