### PR TITLE
Fix issue with type mismatch in helper template

### DIFF
--- a/charts/config-syncer/Chart.yaml
+++ b/charts/config-syncer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Config Syncer by AppsCode'
 name: config-syncer
-version: v0.14.2
+version: 0.14.3
 appVersion: v0.14.1
 home: https://github.com/kubeops/config-syncer
 icon: https://cdn.appscode.com/images/products/kubed/icons/android-icon-192x192.png

--- a/charts/config-syncer/README.md
+++ b/charts/config-syncer/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/config-syncer --version=v0.14.2
-$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.2
+$ helm search repo appscode/config-syncer --version=v0.14.3
+$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.3
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Config Syncer operator on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `config-syncer`:
 
 ```bash
-$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.2
+$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.3
 ```
 
 The command deploys a Config Syncer operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -87,12 +87,12 @@ The following table lists the configurable parameters of the `config-syncer` cha
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.2 --set replicaCount=1
+$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.3 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.2 --values values.yaml
+$ helm upgrade -i config-syncer appscode/config-syncer -n kubeops --create-namespace --version=v0.14.3 --values values.yaml
 ```

--- a/charts/config-syncer/templates/_helpers.tpl
+++ b/charts/config-syncer/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Returns the appscode license
 */}}
 {{- define "mode.enterprise" -}}
-{{- ternary "enterpise" "" (or .Values.license (eq .Values.mode "enterprise")) -}}
+{{- ternary "enterpise" "" (or (ne .Values.license "") (eq .Values.mode "enterprise")) -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The or function expects Boolean parameters and license is a string.  This takes care of converting it based on contents.

Signed-off-by: Kyle Michel <kyle.michel@finvi.com>