### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -42,8 +45,8 @@ jobs:
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -55,7 +58,7 @@ jobs:
 
       - name: Publish OCI charts
         env:
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -42,7 +42,7 @@ jobs:
 
       - name: Package
         env:
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           ./hack/scripts/update-chart-dependencies.sh

--- a/.github/workflows/update-local-repo.yml
+++ b/.github/workflows/update-local-repo.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Update Local Helm repo
         env:
-          GITHUB_USER: 1gtm
+          GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./hack/scripts/trigger.sh


### PR DESCRIPTION
## Summary

Apply the CI hardening pattern from appscode-cloud/installer#1252.

- `publish-oci.yml`: add least-privilege job permissions (`contents: write`, `packages: write`); switch the env `GITHUB_USER` / `GITHUB_TOKEN` in `Clone charts repository` and `Publish OCI charts` from `1gtm` / `LGTM_GITHUB_TOKEN` to `github.actor` / `GITHUB_TOKEN`.
- `release.yml`: same env swap in `Clone charts repository` and `Package`. Job-level `permissions: contents: write` was already present.
- `update-local-repo.yml`: env `GITHUB_USER: 1gtm` → `${{ github.actor }}` in `Update Local Helm repo` (`GITHUB_TOKEN` was already the default).
- The ghcr.io docker login still uses `LGTM_GITHUB_TOKEN` since publishing to the `appscode-charts` org requires cross-org write access.
- `release-tracker.yml` already uses the LGTM App token (owner `appscode-cloud`, repositories `CHANGELOG`); not touched here.

## Test plan

- [ ] Next tag push triggers `release` + `publish-oci` and both succeed.
- [ ] Next push to `master` triggers `update-local-repo` and the helm repo update PR is opened as `${{ github.actor }}`.