### PR TITLE
ci(update-local-repo): stop checkout from overriding LGTM token

### DIFF
--- a/.github/workflows/update-local-repo.yml
+++ b/.github/workflows/update-local-repo.yml
@@ -18,6 +18,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # Don't let actions/checkout install an http.extraheader carrying
+          # the auto-injected GITHUB_TOKEN — it would otherwise override the
+          # LGTM-app credentials embedded in the remote URL by the
+          # "Prepare git" step below, causing the push in trigger.sh to fail
+          # with a 403 ("Permission to kubeops/installer.git denied to
+          # github-actions[bot]").
+          persist-credentials: false
 
       - name: Generate LGTM App token
         id: lgtm-app-token


### PR DESCRIPTION
## Summary

Fixes https://github.com/kubeops/installer/actions/runs/26828259208/job/79101864595 (and every prior \`update-local-repo\` failure on \`master\`).

\`actions/checkout@v4.3.1\` defaults \`persist-credentials: true\`, which installs an \`http.https://github.com/.extraheader\` carrying the auto-injected \`GITHUB_TOKEN\`. That header beats the basic-auth credentials the next \"Prepare git\" step embeds in the remote URL via \`git remote set-url\`, so \`trigger.sh\`'s final \`git push\` runs as \`github-actions[bot]\` (not the LGTM app) and is denied:

\`\`\`
remote: Permission to kubeops/installer.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kubeops/installer.git/': The requested URL returned error: 403
\`\`\`

Setting \`persist-credentials: false\` skips the extraheader install, so the URL-embedded LGTM-app token is what git actually uses on push.

## Test plan

- [ ] Merge and observe the next \`master\` push triggers a successful \`update-local-repo\` run (the autofixer PR gets opened by \`1gtm[bot]\` instead of failing with 403).