### PR TITLE
kube-ui-server: rename editortemplates RBAC to editormodels

### DIFF
--- a/charts/kube-ui-server/templates/user-roles.yaml
+++ b/charts/kube-ui-server/templates/user-roles.yaml
@@ -84,7 +84,7 @@ rules:
 - apiGroups:
   - editor.ui.k8s.appscode.com
   resources:
-  - editortemplates
+  - editormodels
   verbs: ["create"]
 - apiGroups:
   - meta.k8s.appscode.com


### PR DESCRIPTION
Follow-up to #493. The `editor.ui.k8s.appscode.com` kind `EditorTemplate` was renamed to **`EditorModel`** (resource `editormodels`); update the `system:authenticated` create grant in user-roles accordingly. The group-wide ClusterRole and APIService are unaffected (same group).

Related: kmodules/resource-metadata (rename), kubeops/ui-server (rename), appscode-cloud/b3#1527.