### PR TITLE
Set config-syncer CI license via LICENSE_KEY in unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,8 @@ $(OUTBIN): $(BUILD_DIRS)
 .PHONY: test
 test: unit-tests
 
+TEST_LICENSE_KEY ?= fake-license
+
 unit-tests: $(BUILD_DIRS)
 	@docker run                                                 \
 	    -i                                                      \
@@ -306,11 +308,13 @@ unit-tests: $(BUILD_DIRS)
 	    -v $$(pwd)/.go/cache:/.cache                            \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
+	    --env TEST_LICENSE_KEY=$(TEST_LICENSE_KEY)              \
 	    $(BUILD_IMAGE)                                          \
 	    /bin/bash -c "                                          \
 	        ARCH=$(ARCH)                                        \
 	        OS=$(OS)                                            \
 	        VERSION=$(VERSION)                                  \
+	        LICENSE_KEY=$(LICENSE_KEY)                          \
 	        ./hack/test.sh $(SRC_PKGS)                          \
 	    "
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	kmodules.xyz/image-packer v0.0.0-20260708055132-ed3c452e3c7f
 	kmodules.xyz/resource-metadata v0.47.0
 	kmodules.xyz/schema-checker v0.4.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -102,7 +103,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 	x-helm.dev/apimachinery v0.0.18 // indirect
 )
 

--- a/tests/check-charts_test.go
+++ b/tests/check-charts_test.go
@@ -18,12 +18,41 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"kmodules.xyz/image-packer/pkg/lib"
+	"sigs.k8s.io/yaml"
 )
+
+// TestMain sets the license in the config-syncer CI values before running the
+// tests
+func TestMain(m *testing.M) {
+	if err := setConfigSyncerLicense(os.Getenv("TEST_LICENSE_KEY")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+func setConfigSyncerLicense(licenseKey string) error {
+	dir, err := rootDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "charts", "config-syncer", "ci", "ci-values.yaml")
+
+	out, err := yaml.Marshal(map[string]any{
+		"license": licenseKey,
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
 
 func Test_CheckImageArchitectures(t *testing.T) {
 	dir, err := rootDir()


### PR DESCRIPTION
Inject the config-syncer license into `charts/config-syncer/ci/ci-values.yaml` from a `LICENSE_KEY` env var in Go `TestMain` (using `sigs.k8s.io/yaml`) instead of a `yq` step, and pass `LICENSE_KEY` through the `unit-tests` make target. Drop the now-unneeded yq/kubectl host-prep step from the CI build job.

Resolved conflicts against current `master`:
- Kept master's newer `kmodules.xyz/image-packer` (`ed3c452e3c7f`) over the version this change originally bumped to.
- `sigs.k8s.io/yaml` promoted from indirect to direct.

Verified locally: `go vet ./tests/...` and `go mod verify` pass.