### PR TITLE
storage-metrics-server: prefer InternalIP for kubelet address

### DIFF
--- a/charts/storage-metrics-server/values.yaml
+++ b/charts/storage-metrics-server/values.yaml
@@ -35,8 +35,8 @@ replicaCount: 1
 # kubelet TLS flags, scrape interval, log verbosity, etc.
 extraArgs:
   - --kubelet-insecure-tls           # remove in production
+  - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
 #  - --kubelet-use-node-status-port
-#  - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
 #  - --metric-resolution=60s
 #  - --kubelet-request-timeout=10s
 #  - --v=2


### PR DESCRIPTION
Uncomments `--kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP` in the chart defaults.

Without it the server dials the node hostname, which cluster DNS typically cannot resolve, and every scrape fails with `no such host`.

This is the change that fixes existing installs; the binary-side default is fixed in kubeops/storage-metrics-server#7 but only takes effect with a new image.